### PR TITLE
feat: support date ranges (start + end) in page set

### DIFF
--- a/cmd/page.go
+++ b/cmd/page.go
@@ -1093,8 +1093,13 @@ func buildPropertyValue(propType, value string) interface{} {
 			"status": map[string]interface{}{"name": value},
 		}
 	case "date":
+		parts := strings.SplitN(value, "/", 2)
+		d := map[string]interface{}{"start": parts[0]}
+		if len(parts) == 2 {
+			d["end"] = parts[1]
+		}
 		return map[string]interface{}{
-			"date": map[string]interface{}{"start": value},
+			"date": d,
 		}
 	case "checkbox":
 		return map[string]interface{}{

--- a/cmd/page_test.go
+++ b/cmd/page_test.go
@@ -83,6 +83,30 @@ func TestBuildPropertyValueMultiSelect(t *testing.T) {
 	}
 }
 
+func TestBuildPropertyValueDateRange(t *testing.T) {
+	// Single date (backward compatible)
+	result := buildPropertyValue("date", "2026-03-07")
+	m := result.(map[string]interface{})
+	d := m["date"].(map[string]interface{})
+	if d["start"] != "2026-03-07" {
+		t.Errorf("start = %q, want 2026-03-07", d["start"])
+	}
+	if _, hasEnd := d["end"]; hasEnd {
+		t.Error("single date should not have end key")
+	}
+
+	// Date range with /
+	result2 := buildPropertyValue("date", "2026-03-07T20:00:00+01:00/2026-03-07T21:00:00+01:00")
+	m2 := result2.(map[string]interface{})
+	d2 := m2["date"].(map[string]interface{})
+	if d2["start"] != "2026-03-07T20:00:00+01:00" {
+		t.Errorf("start = %q, want 2026-03-07T20:00:00+01:00", d2["start"])
+	}
+	if d2["end"] != "2026-03-07T21:00:00+01:00" {
+		t.Errorf("end = %q, want 2026-03-07T21:00:00+01:00", d2["end"])
+	}
+}
+
 func TestBuildPropertyValueTitle(t *testing.T) {
 	result := buildPropertyValue("title", "My Title")
 	m := result.(map[string]interface{})


### PR DESCRIPTION
Closes #1

Uses `/` separator to split start and end dates in `page set`:

```bash
# Date range
notion page set <id> 'Due=2026-03-07T20:00:00+01:00/2026-03-07T21:00:00+01:00'

# Single date (unchanged)
notion page set <id> 'Due=2026-03-07'
```

**Changes:**
- `buildPropertyValue`: split date value on `/`, set `end` if present
- Added `TestBuildPropertyValueDateRange` covering both single and range cases
- Fully backward compatible