### PR TITLE
docs: fix auth CLI flags to match implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@
 
 ```
 notion auth login              # Interactive: open browser → OAuth flow
-notion auth login --token      # Paste an integration token directly
+notion auth login --with-token  # Read an integration token from stdin
 notion auth logout
 notion auth status             # Show current auth state
 notion auth switch             # Switch between multiple workspaces
@@ -145,7 +145,6 @@ Like `gh api` — for anything the CLI doesn't cover yet.
 ```
 --format json|table|text|md    # Output format (default: auto-detect tty)
 --workspace <name>             # Use specific workspace
---token <token>                # Override auth token
 --no-cache                     # Skip local cache
 --debug                        # Show HTTP requests/responses
 --quiet                        # Minimal output
@@ -180,7 +179,7 @@ Last edited: 2 hours ago by @alice
 ## MVP Scope (v0.1.0)
 
 ### Must have:
-1. `notion auth login --token` + `NOTION_TOKEN` env var
+1. `notion auth login --with-token` + `NOTION_TOKEN` env var
 2. `notion search`
 3. `notion page view` + `notion page list`
 4. `notion page create` (simple: title + optional text body)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Download from [GitHub Releases](https://github.com/4ier/notion-cli/releases) —
 
 ```sh
 # Authenticate
-notion auth login --token ntn_xxxxx
+echo "ntn_xxxxx" | notion auth login --with-token
 
 # Search your workspace
 notion search "meeting notes"
@@ -82,7 +82,7 @@ notion api GET /v1/users/me
 
 | Group | Commands | Description |
 |-------|----------|-------------|
-| **auth** | `login` `logout` `status` `doctor` | Authentication & diagnostics |
+| **auth** | `login` `logout` `status` `switch` `doctor` | Authentication & diagnostics |
 | **search** | `search` | Search pages and databases |
 | **page** | `view` `list` `create` `delete` `restore` `move` `open` `set` `props` `link` `unlink` | Full page lifecycle |
 | **db** | `list` `view` `query` `create` `update` `add` `add-bulk` `open` | Database CRUD + query |
@@ -170,7 +170,7 @@ npx skills add 4ier/notion-cli
 
 ```sh
 # Token is stored in ~/.config/notion-cli/config.json (mode 0600)
-notion auth login --token ntn_xxxxx
+echo "ntn_xxxxx" | notion auth login --with-token
 
 # Or use environment variable
 export NOTION_TOKEN=ntn_xxxxx


### PR DESCRIPTION
## Summary
- `--token` → `--with-token`: README.md and DESIGN.md documented a non-existent `--token` flag. The actual flag is `--with-token` (boolean, reads token from stdin).
- Removed `--token <token>` from DESIGN.md global flags section (not implemented).
- Added missing `switch` subcommand to README.md auth commands table.

SKILL.md was already correct — no changes needed.

## Test plan
- [ ] Verify `notion auth login --with-token` matches code in `cmd/auth.go`
- [ ] Confirm no remaining `--token` references in docs