### PR TITLE
fix(auth): doctor reads token from current profile

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -348,7 +348,12 @@ Examples:
 
 		// Check 1: Config file
 		cfg, err := config.Load()
-		if err != nil || cfg.Token == "" {
+		profile := cfg.GetCurrentProfile()
+		token := cfg.Token
+		if token == "" && profile != nil {
+			token = profile.Token
+		}
+		if err != nil || token == "" {
 			fmt.Println("  ✗ Config: no token found")
 			fmt.Println("    Run: notion auth login --with-token")
 			return nil
@@ -356,7 +361,7 @@ Examples:
 		fmt.Println("  ✓ Config: token found")
 
 		// Check 2: Token validity
-		c := client.New(cfg.Token)
+		c := client.New(token)
 		me, err := c.GetMe()
 		if err != nil {
 			fmt.Printf("  ✗ Auth: token is invalid (%v)\n", err)


### PR DESCRIPTION
## Summary

Fixes #5

`notion auth doctor` always failed with `✗ Config: no token found` even after a successful `notion auth login`, because it was checking the legacy top-level `cfg.Token` field — which is cleared by `MigrateToProfiles()` when the new profile format is used.

## Root Cause

```go
// cmd/auth.go — before fix
cfg, err := config.Load()
if err != nil || cfg.Token == "" {   // cfg.Token is "" after profile-based login
```

`auth login` stores the token in `cfg.Profiles["default"].Token`, not `cfg.Token`. After `MigrateToProfiles()` runs, the top-level `Token` field is cleared.

## Fix

Resolve the token via `GetCurrentProfile()` (the existing accessor) when the legacy field is empty, then use that token for both the nil-check and the API client:

```go
cfg, err := config.Load()
profile := cfg.GetCurrentProfile()
token := cfg.Token
if token == "" && profile != nil {
    token = profile.Token
}
if err != nil || token == "" {
    // ...
}
c := client.New(token)
```

## Testing

**Before:** `notion auth login` → `notion auth doctor` → `✗ Config: no token found`  
**After:** `notion auth login` → `notion auth doctor` → `All checks passed ✓`