### PR TITLE
Add true user mentions to comment add

### DIFF
--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/4ier/notion-cli/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // setupAuthTest creates a mock Notion API server and sets env vars for isolated testing.
@@ -71,12 +73,36 @@ func executeCommand(args ...string) (string, string, error) {
 	stderr := new(bytes.Buffer)
 
 	cmd := rootCmd
+	resetCommandFlags(cmd)
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
 	cmd.SetArgs(args)
 
 	err := cmd.Execute()
 	return stdout.String(), stderr.String(), err
+}
+
+func resetCommandFlags(cmd interface{ Flags() *pflag.FlagSet; PersistentFlags() *pflag.FlagSet; Commands() []*cobra.Command }) {
+	resetFlagSet(cmd.Flags())
+	resetFlagSet(cmd.PersistentFlags())
+	for _, sub := range cmd.Commands() {
+		resetCommandFlags(sub)
+	}
+}
+
+func resetFlagSet(fs *pflag.FlagSet) {
+	if fs == nil {
+		return
+	}
+
+	fs.VisitAll(func(f *pflag.Flag) {
+		if sliceValue, ok := f.Value.(pflag.SliceValue); ok {
+			_ = sliceValue.Replace(nil)
+		} else {
+			_ = f.Value.Set(f.DefValue)
+		}
+		f.Changed = false
+	})
 }
 
 // --- auth login ---

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/4ier/notion-cli/internal/client"
 	"github.com/4ier/notion-cli/internal/render"
@@ -101,26 +102,31 @@ Examples:
 }
 
 var commentAddCmd = &cobra.Command{
-	Use:   "add <page-id|url> <text>",
+	Use:   "add <page-id|url> [text]",
 	Short: "Add a comment to a page",
 	Long: `Add a comment to a Notion page.
 
 Examples:
-  notion comment add abc123 "This looks great!"`,
-	Args: cobra.ExactArgs(2),
+  notion comment add abc123 "This looks great!"
+  notion comment add abc123 --mention-user user-123 --text "Please review this"
+  notion comment add abc123 --mention-user user-123 --mention-user user-456 --text "Please review this"`,
+	Args: validateCommentAddArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		pageID := util.ResolveID(args[0])
+		text, mentionUserIDs, err := resolveCommentAddContent(cmd, args)
+		if err != nil {
+			return err
+		}
+
 		token, err := getToken()
 		if err != nil {
 			return err
 		}
 
-		pageID := util.ResolveID(args[0])
-		text := args[1]
-
 		c := client.New(token)
 		c.SetDebug(debugMode)
 
-		data, err := c.AddComment(pageID, text)
+		data, err := c.AddComment(pageID, text, mentionUserIDs)
 		if err != nil {
 			return fmt.Errorf("add comment: %w", err)
 		}
@@ -128,21 +134,55 @@ Examples:
 		if outputFormat == "json" {
 			var result map[string]interface{}
 			if err := json.Unmarshal(data, &result); err != nil {
-		return fmt.Errorf("parse response: %w", err)
-	}
+				return fmt.Errorf("parse response: %w", err)
+			}
 			return render.JSON(result)
 		}
 
 		var result map[string]interface{}
 		if err := json.Unmarshal(data, &result); err != nil {
-		return fmt.Errorf("parse response: %w", err)
-	}
+			return fmt.Errorf("parse response: %w", err)
+		}
 		id, _ := result["id"].(string)
 
-		render.Title("✓", "Comment added")
-		render.Field("ID", id)
+		fmt.Fprintf(cmd.OutOrStdout(), "✓ Comment added\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "ID:             %s\n", id)
 		return nil
 	},
+}
+
+func validateCommentAddArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return cobra.RangeArgs(1, 2)(cmd, args)
+	}
+
+	_, _, err := resolveCommentAddContent(cmd, args)
+	return err
+}
+
+func resolveCommentAddContent(cmd *cobra.Command, args []string) (string, []string, error) {
+	flagText, _ := cmd.Flags().GetString("text")
+	mentionUserIDs, _ := cmd.Flags().GetStringArray("mention-user")
+
+	if len(args) == 2 && flagText != "" {
+		return "", nil, fmt.Errorf("provide comment text either as an argument or with --text, not both")
+	}
+
+	text := flagText
+	if len(args) == 2 {
+		text = args[1]
+	}
+
+	if strings.TrimSpace(text) == "" && len(mentionUserIDs) == 0 {
+		return "", nil, fmt.Errorf("comment content required: provide text or at least one --mention-user")
+	}
+
+	resolvedMentionUserIDs := make([]string, len(mentionUserIDs))
+	for i, userID := range mentionUserIDs {
+		resolvedMentionUserIDs[i] = util.ResolveID(userID)
+	}
+
+	return text, resolvedMentionUserIDs, nil
 }
 
 var commentGetCmd = &cobra.Command{
@@ -275,6 +315,8 @@ Examples:
 func init() {
 	commentListCmd.Flags().String("cursor", "", "Pagination cursor")
 	commentListCmd.Flags().Bool("all", false, "Fetch all pages of results")
+	commentAddCmd.Flags().String("text", "", "Comment text")
+	commentAddCmd.Flags().StringArray("mention-user", nil, "Mention a Notion user by ID (repeatable)")
 
 	commentCmd.AddCommand(commentListCmd)
 	commentCmd.AddCommand(commentAddCmd)

--- a/cmd/comment_test.go
+++ b/cmd/comment_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCommentAddWithMentionUsersUsesRichTextMentions(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/comments" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "comment-123"})
+	}))
+	defer server.Close()
+
+	t.Setenv("NOTION_BASE_URL", server.URL)
+	t.Setenv("NOTION_TOKEN", "test-token")
+	outputFormat = ""
+	debugMode = false
+
+	pageID := "31f4d69381a180629761e1f7c6dd6e7c"
+	user1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	user2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	stdout, _, err := executeCommand(
+		"comment", "add", pageID,
+		"--mention-user", user1,
+		"--mention-user", user2,
+		"--text", "Please review this",
+	)
+	if err != nil {
+		t.Fatalf("executeCommand returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "Comment added") {
+		t.Fatalf("stdout = %q, want success output", stdout)
+	}
+
+	parent, ok := gotBody["parent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("parent = %T, want map[string]interface{}", gotBody["parent"])
+	}
+	if parent["page_id"] != "31f4d693-81a1-8062-9761-e1f7c6dd6e7c" {
+		t.Fatalf("page_id = %v, want dashed UUID", parent["page_id"])
+	}
+
+	richText, ok := gotBody["rich_text"].([]interface{})
+	if !ok {
+		t.Fatalf("rich_text = %T, want []interface{}", gotBody["rich_text"])
+	}
+	if len(richText) != 5 {
+		t.Fatalf("len(rich_text) = %d, want 5", len(richText))
+	}
+
+	assertMention := func(idx int, wantID string) {
+		t.Helper()
+		item, ok := richText[idx].(map[string]interface{})
+		if !ok {
+			t.Fatalf("rich_text[%d] = %T, want map[string]interface{}", idx, richText[idx])
+		}
+		if item["type"] != "mention" {
+			t.Fatalf("rich_text[%d].type = %v, want %q", idx, item["type"], "mention")
+		}
+		mention, ok := item["mention"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("rich_text[%d].mention = %T, want map[string]interface{}", idx, item["mention"])
+		}
+		user, ok := mention["user"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("rich_text[%d].mention.user = %T, want map[string]interface{}", idx, mention["user"])
+		}
+		if user["id"] != wantID {
+			t.Fatalf("rich_text[%d].mention.user.id = %v, want %q", idx, user["id"], wantID)
+		}
+	}
+
+	assertText := func(idx int, want string) {
+		t.Helper()
+		item, ok := richText[idx].(map[string]interface{})
+		if !ok {
+			t.Fatalf("rich_text[%d] = %T, want map[string]interface{}", idx, richText[idx])
+		}
+		if item["type"] != "text" {
+			t.Fatalf("rich_text[%d].type = %v, want %q", idx, item["type"], "text")
+		}
+		text, ok := item["text"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("rich_text[%d].text = %T, want map[string]interface{}", idx, item["text"])
+		}
+		if text["content"] != want {
+			t.Fatalf("rich_text[%d].text.content = %v, want %q", idx, text["content"], want)
+		}
+	}
+
+	assertMention(0, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	assertText(1, " ")
+	assertMention(2, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	assertText(3, " ")
+	assertText(4, "Please review this")
+}
+
+func TestCommentAddRequiresTextOrMentionUser(t *testing.T) {
+	t.Setenv("NOTION_TOKEN", "test-token")
+	outputFormat = ""
+	debugMode = false
+
+	_, _, err := executeCommand("comment", "add", "31f4d69381a180629761e1f7c6dd6e7c")
+	if err == nil {
+		t.Fatal("expected error for empty comment")
+	}
+	if !strings.Contains(err.Error(), "provide text or at least one --mention-user") {
+		t.Fatalf("error = %v, want content validation", err)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/4ier/notion-cli/internal/util"
 )
 
 const (
@@ -289,16 +291,48 @@ func (c *Client) ListComments(blockID string, pageSize int, startCursor string) 
 }
 
 // AddComment adds a comment to a page.
-func (c *Client) AddComment(pageID, text string) ([]byte, error) {
+func (c *Client) AddComment(pageID, text string, mentionUserIDs []string) ([]byte, error) {
 	body := map[string]interface{}{
 		"parent": map[string]interface{}{
-			"page_id": pageID,
+			"page_id": util.ResolveID(pageID),
 		},
-		"rich_text": []map[string]interface{}{
-			{"text": map[string]interface{}{"content": text}},
-		},
+		"rich_text": buildCommentRichText(text, mentionUserIDs),
 	}
 	return c.Post("/v1/comments", body)
+}
+
+func buildCommentRichText(text string, mentionUserIDs []string) []map[string]interface{} {
+	var richText []map[string]interface{}
+
+	for i, userID := range mentionUserIDs {
+		richText = append(richText, map[string]interface{}{
+			"type": "mention",
+			"mention": map[string]interface{}{
+				"type": "user",
+				"user": map[string]interface{}{
+					"id": userID,
+				},
+			},
+		})
+		if i < len(mentionUserIDs)-1 || text != "" {
+			richText = append(richText, commentTextRichText(" "))
+		}
+	}
+
+	if text != "" {
+		richText = append(richText, commentTextRichText(text))
+	}
+
+	return richText
+}
+
+func commentTextRichText(text string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "text",
+		"text": map[string]interface{}{
+			"content": text,
+		},
+	}
 }
 
 // UploadFileContent sends file content to an existing file upload via multipart form.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -154,5 +155,91 @@ func TestUploadFileContentEscapesQuotedFilename(t *testing.T) {
 
 	if gotFileName != `report "final".pdf` {
 		t.Fatalf("filename = %q, want %q", gotFileName, `report "final".pdf`)
+	}
+}
+
+func TestAddCommentIncludesMentionRichText(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+
+	c := &Client{
+		token: "test-token",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				gotPath = req.URL.Path
+				if err := json.NewDecoder(req.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"comment-123"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+
+	if _, err := c.AddComment(
+		"page-123",
+		"Please review this",
+		[]string{"user-123", "user-456"},
+	); err != nil {
+		t.Fatalf("AddComment returned error: %v", err)
+	}
+
+	if gotPath != "/v1/comments" {
+		t.Fatalf("path = %q, want %q", gotPath, "/v1/comments")
+	}
+
+	parent, ok := gotBody["parent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("parent = %T, want map[string]interface{}", gotBody["parent"])
+	}
+	if parent["page_id"] != "page-123" {
+		t.Fatalf("page_id = %v, want %q", parent["page_id"], "page-123")
+	}
+
+	richText, ok := gotBody["rich_text"].([]interface{})
+	if !ok {
+		t.Fatalf("rich_text = %T, want []interface{}", gotBody["rich_text"])
+	}
+	if len(richText) != 5 {
+		t.Fatalf("len(rich_text) = %d, want 5", len(richText))
+	}
+
+	first, ok := richText[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rich_text[0] = %T, want map[string]interface{}", richText[0])
+	}
+	if first["type"] != "mention" {
+		t.Fatalf("rich_text[0].type = %v, want %q", first["type"], "mention")
+	}
+
+	mention, ok := first["mention"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rich_text[0].mention = %T, want map[string]interface{}", first["mention"])
+	}
+	user, ok := mention["user"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rich_text[0].mention.user = %T, want map[string]interface{}", mention["user"])
+	}
+	if user["id"] != "user-123" {
+		t.Fatalf("rich_text[0].mention.user.id = %v, want %q", user["id"], "user-123")
+	}
+
+	last, ok := richText[4].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rich_text[4] = %T, want map[string]interface{}", richText[4])
+	}
+	if last["type"] != "text" {
+		t.Fatalf("rich_text[4].type = %v, want %q", last["type"], "text")
+	}
+	text, ok := last["text"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("rich_text[4].text = %T, want map[string]interface{}", last["text"])
+	}
+	if text["content"] != "Please review this" {
+		t.Fatalf("rich_text[4].text.content = %v, want %q", text["content"], "Please review this")
 	}
 }

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -26,14 +26,14 @@ func ResolveID(input string) string {
 		}
 	}
 
-	// Already a UUID with dashes
-	if uuidRe.MatchString(input) {
-		return input
-	}
-
 	// 32-char hex (no dashes)
 	if plainIDRe.MatchString(input) {
 		return formatUUID(input)
+	}
+
+	// Already a UUID with dashes
+	if uuidRe.MatchString(input) {
+		return input
 	}
 
 	// Return as-is (let the API handle the error)

--- a/internal/util/url_test.go
+++ b/internal/util/url_test.go
@@ -16,7 +16,7 @@ func TestResolveID(t *testing.T) {
 		{
 			name:  "UUID without dashes (32 hex chars)",
 			input: "c9e9f681ec8e4eb7be25bbbe479b05b0",
-			want:  "c9e9f681ec8e4eb7be25bbbe479b05b0",
+			want:  "c9e9f681-ec8e-4eb7-be25-bbbe479b05b0",
 		},
 		{
 			name:  "notion.so URL with page name",


### PR DESCRIPTION
Closes #16

## Summary
- add repeatable `--mention-user` support to `notion comment add`
- build real Notion rich_text user mentions instead of plain text @ strings
- validate comment content before auth/API calls
- add tests for mention payloads and command behavior
- fix 32-char Notion ID normalization so undashed IDs are converted consistently

## Validation
- go test ./...
- verified against a real Notion test task with a live mention comment