### PR TITLE
feat(block): add --image-url flag for external image blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ notion block append <page-id> --file document.md
 ```
 Supports headings, bullets, numbered lists, todos, quotes, code blocks, and dividers.
 
+### External Images
+Insert or append an image block by URL (no upload — points to externally hosted image):
+```sh
+# Insert after a specific block (e.g. next to a "TODO: add figure" placeholder)
+notion block insert <page-id> --after <block-id> \
+  --image-url https://example.com/diagram.png \
+  --caption "Figure 1 — architecture"
+
+# Append to end of page
+notion block append <page-id> --image-url https://example.com/diagram.png
+```
+
 ### Recursive Block Reading
 ```sh
 notion block list <page-id> --depth 5 --all

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -197,7 +197,8 @@ Examples:
   notion block append <page-id> "Hello world"
   notion block append <page-id> --type heading1 "Section Title"
   notion block append <page-id> --type code --lang go "fmt.Println()"
-  notion block append <page-id> --file notes.md`,
+  notion block append <page-id> --file notes.md
+  notion block append <page-id> --image-url https://example.com/a.png --caption "图 1-1"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token, err := getToken()
@@ -208,6 +209,17 @@ Examples:
 		parentID := util.ResolveID(args[0])
 		blockType, _ := cmd.Flags().GetString("type")
 		filePath, _ := cmd.Flags().GetString("file")
+		imageURL, _ := cmd.Flags().GetString("image-url")
+		caption, _ := cmd.Flags().GetString("caption")
+
+		text := ""
+		if len(args) > 1 {
+			text = args[1]
+		}
+
+		if err := validateMediaFlags(imageURL, filePath, text); err != nil {
+			return err
+		}
 
 		if blockType == "" {
 			blockType = "paragraph"
@@ -218,7 +230,9 @@ Examples:
 
 		var children []map[string]interface{}
 
-		if filePath != "" {
+		if imageURL != "" {
+			children = append(children, buildExternalImageBlock(imageURL, caption))
+		} else if filePath != "" {
 			// Read file and parse markdown to blocks
 			data, err := os.ReadFile(filePath)
 			if err != nil {
@@ -226,12 +240,8 @@ Examples:
 			}
 			children = parseMarkdownToBlocks(string(data))
 		} else {
-			text := ""
-			if len(args) > 1 {
-				text = args[1]
-			}
 			if text == "" {
-				return fmt.Errorf("text content or --file is required")
+				return fmt.Errorf("text content, --file, or --image-url is required")
 			}
 
 			notionType := mapBlockType(blockType)
@@ -324,7 +334,8 @@ var blockInsertCmd = &cobra.Command{
 Examples:
   notion block insert <page-id> "New paragraph" --after <block-id>
   notion block insert <page-id> "Section" --after <block-id> --type h2
-  notion block insert <page-id> --file notes.md --after <block-id>`,
+  notion block insert <page-id> --file notes.md --after <block-id>
+  notion block insert <page-id> --after <block-id> --image-url https://example.com/a.png --caption "图 1-1"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token, err := getToken()
@@ -336,6 +347,17 @@ Examples:
 		afterID, _ := cmd.Flags().GetString("after")
 		blockType, _ := cmd.Flags().GetString("type")
 		filePath, _ := cmd.Flags().GetString("file")
+		imageURL, _ := cmd.Flags().GetString("image-url")
+		caption, _ := cmd.Flags().GetString("caption")
+
+		text := ""
+		if len(args) > 1 {
+			text = args[1]
+		}
+
+		if err := validateMediaFlags(imageURL, filePath, text); err != nil {
+			return err
+		}
 
 		if afterID == "" {
 			return fmt.Errorf("--after <block-id> is required (use 'block append' to add to end)")
@@ -351,19 +373,17 @@ Examples:
 
 		var children []map[string]interface{}
 
-		if filePath != "" {
+		if imageURL != "" {
+			children = append(children, buildExternalImageBlock(imageURL, caption))
+		} else if filePath != "" {
 			data, err := os.ReadFile(filePath)
 			if err != nil {
 				return fmt.Errorf("read file: %w", err)
 			}
 			children = parseMarkdownToBlocks(string(data))
 		} else {
-			text := ""
-			if len(args) > 1 {
-				text = args[1]
-			}
 			if text == "" {
-				return fmt.Errorf("text content or --file is required")
+				return fmt.Errorf("text content, --file, or --image-url is required")
 			}
 
 			notionType := mapBlockType(blockType)
@@ -560,10 +580,14 @@ func init() {
 	blockAppendCmd.Flags().StringP("type", "t", "paragraph", "Block type: paragraph, h1, h2, h3, todo, bullet, numbered, quote, code, callout, divider")
 	blockAppendCmd.Flags().String("lang", "plain text", "Language for code blocks (e.g. go, python, bash)")
 	blockAppendCmd.Flags().String("file", "", "Read content from a file (each double-newline-separated section becomes a block)")
+	blockAppendCmd.Flags().String("image-url", "", "Append an external image block by URL (http/https)")
+	blockAppendCmd.Flags().String("caption", "", "Caption for --image-url (optional)")
 	blockInsertCmd.Flags().String("after", "", "Block ID to insert after (required)")
 	blockInsertCmd.Flags().StringP("type", "t", "paragraph", "Block type")
 	blockInsertCmd.Flags().String("lang", "plain text", "Language for code blocks")
 	blockInsertCmd.Flags().String("file", "", "Read content from a file")
+	blockInsertCmd.Flags().String("image-url", "", "Insert an external image block by URL (http/https)")
+	blockInsertCmd.Flags().String("caption", "", "Caption for --image-url (optional)")
 	blockListCmd.Flags().String("cursor", "", "Pagination cursor")
 	blockListCmd.Flags().Bool("all", false, "Fetch all pages of results")
 	blockListCmd.Flags().Int("depth", 1, "Depth of nested blocks to fetch (default 1)")
@@ -581,6 +605,39 @@ func init() {
 	blockCmd.AddCommand(blockUpdateCmd)
 	blockCmd.AddCommand(blockDeleteCmd)
 	blockCmd.AddCommand(blockMoveCmd)
+}
+
+func buildExternalImageBlock(url, caption string) map[string]interface{} {
+	image := map[string]interface{}{
+		"type":     "external",
+		"external": map[string]interface{}{"url": url},
+	}
+	if caption != "" {
+		image["caption"] = []map[string]interface{}{
+			{"type": "text", "text": map[string]interface{}{"content": caption}},
+		}
+	}
+	return map[string]interface{}{
+		"object": "block",
+		"type":   "image",
+		"image":  image,
+	}
+}
+
+func validateMediaFlags(imageURL, filePath, text string) error {
+	if imageURL == "" {
+		return nil
+	}
+	if filePath != "" {
+		return fmt.Errorf("--image-url cannot be combined with --file")
+	}
+	if text != "" {
+		return fmt.Errorf("--image-url cannot be combined with a positional text argument")
+	}
+	if !strings.HasPrefix(imageURL, "http://") && !strings.HasPrefix(imageURL, "https://") {
+		return fmt.Errorf("--image-url must be an http:// or https:// URL")
+	}
+	return nil
 }
 
 func mapBlockType(t string) string {

--- a/cmd/block_test.go
+++ b/cmd/block_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -485,6 +486,78 @@ func TestMapBlockTypeAliases(t *testing.T) {
 			got := mapBlockType(tt.input)
 			if got != tt.want {
 				t.Errorf("mapBlockType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildExternalImageBlock(t *testing.T) {
+	t.Run("without caption", func(t *testing.T) {
+		b := buildExternalImageBlock("https://example.com/a.png", "")
+		if b["type"] != "image" {
+			t.Fatalf("type = %v, want image", b["type"])
+		}
+		img, ok := b["image"].(map[string]interface{})
+		if !ok {
+			t.Fatal("image field not a map")
+		}
+		if img["type"] != "external" {
+			t.Errorf("image.type = %v, want external", img["type"])
+		}
+		ext, _ := img["external"].(map[string]interface{})
+		if ext["url"] != "https://example.com/a.png" {
+			t.Errorf("external.url = %v", ext["url"])
+		}
+		if _, has := img["caption"]; has {
+			t.Error("caption should be omitted when empty")
+		}
+	})
+
+	t.Run("with caption", func(t *testing.T) {
+		b := buildExternalImageBlock("https://x/y.png", "图 1-1 悬挂式")
+		img, _ := b["image"].(map[string]interface{})
+		cap, ok := img["caption"].([]map[string]interface{})
+		if !ok || len(cap) != 1 {
+			t.Fatalf("caption shape wrong: %#v", img["caption"])
+		}
+		txt, _ := cap[0]["text"].(map[string]interface{})
+		if txt["content"] != "图 1-1 悬挂式" {
+			t.Errorf("caption content = %v", txt["content"])
+		}
+	})
+}
+
+func TestValidateMediaFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageURL string
+		filePath string
+		text     string
+		wantErr  string
+	}{
+		{"no image url passes", "", "notes.md", "hi", ""},
+		{"valid https", "https://x/y.png", "", "", ""},
+		{"valid http", "http://x/y.png", "", "", ""},
+		{"ftp rejected", "ftp://x/y.png", "", "", "http://"},
+		{"plain text rejected", "not-a-url", "", "", "http://"},
+		{"empty url treated as absent", "", "", "", ""},
+		{"image-url with file conflicts", "https://x/y.png", "notes.md", "", "--file"},
+		{"image-url with text conflicts", "https://x/y.png", "", "hello", "positional text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMediaFlags(tt.imageURL, tt.filePath, tt.text)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want contains %q", err.Error(), tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds `--image-url` (and optional `--caption`) flags to `block append` and `block insert`, letting users attach externally-hosted images without dropping to the raw API.

Motivation: I wanted to backfill images into a page full of "TODO: add figure" placeholders. The only existing options were:
- `file upload --to <page>` — always appends to the end, no positional control
- `block insert --after <block>` — only accepts text / markdown files, no image support

So positioning an image next to a specific placeholder required a hand-rolled `notion api PATCH /v1/blocks/<parent>/children` call. This PR closes that gap for the simplest case: external image URLs.

## Usage

```sh
# Insert after a specific block
notion block insert <page-id> --after <block-id> \
  --image-url https://example.com/diagram.png \
  --caption "Figure 1 — architecture"

# Append to end of page
notion block append <page-id> --image-url https://example.com/diagram.png
```

## Design choices

- **External URLs only** — keeps the scope tiny and doesn't touch the `file upload` pipeline. A follow-up PR could add positional file-upload insertion.
- **Mutually exclusive** with `--file` and positional text argument; clear error messages when mixed.
- **URL validation** requires `http://` or `https://`; otherwise errors locally before hitting the API.
- **Symmetry**: both `insert` and `append` support it, sharing a single `buildExternalImageBlock` helper.

## Test plan

- [x] Unit tests added:
  - `TestBuildExternalImageBlock` — helper produces correct block shape with/without caption
  - `TestValidateMediaFlags` — URL scheme + flag mutual-exclusion checks (8 cases)
- [x] Full suite green (`go test ./...`)
- [x] Smoke tested on a real Notion page — image block lands at the correct position and renders in the Notion UI (when the URL host is reachable and un-rate-limited)

## Notes

- No new dependencies.
- Does not touch `cmd/file.go` or the Notion client.
- README updated with an "External Images" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)