### PR TITLE
fix(api): polish path, body, and help for the escape-hatch command

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -18,9 +18,18 @@ var apiCmd = &cobra.Command{
 
 This is an escape hatch for any operation not yet covered by the CLI.
 
+The <path> must target the Notion API (starts with /v1/). For convenience,
+paths that start with "/" but not "/v1/" are auto-prefixed with /v1/.
+
+Body can be provided three ways:
+  --body '<json>'         inline JSON string
+  --body @<path>          read JSON from a file
+  (stdin)                 pipe JSON on stdin for POST/PATCH/PUT
+
 Examples:
   notion api GET /v1/users/me
   notion api POST /v1/search --body '{"query":"test"}'
+  notion api PATCH /v1/blocks/<id>/children --body @children.json
   echo '{"query":"test"}' | notion api POST /v1/search`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,19 +39,31 @@ Examples:
 		}
 
 		method := strings.ToUpper(args[0])
-		path := args[1]
-
-		// Ensure path starts with /
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
+		path := normalizeAPIPath(args[1])
 
 		bodyStr, _ := cmd.Flags().GetString("body")
 
-		// Read body from stdin if not provided via flag
+		// Support --body @file.json to read body from file.
+		if strings.HasPrefix(bodyStr, "@") {
+			filePath := strings.TrimPrefix(bodyStr, "@")
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				return fmt.Errorf("read body file: %w", err)
+			}
+			bodyStr = string(data)
+		}
+
+		// Read body from stdin if not provided via flag (or --body - explicit stdin).
+		if bodyStr == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read body from stdin: %w", err)
+			}
+			bodyStr = string(data)
+		}
 		if bodyStr == "" && (method == "POST" || method == "PATCH" || method == "PUT") {
 			stat, _ := os.Stdin.Stat()
-			if stat.Mode()&os.ModeCharDevice == 0 {
+			if stat != nil && stat.Mode()&os.ModeCharDevice == 0 {
 				data, err := io.ReadAll(os.Stdin)
 				if err == nil && len(data) > 0 {
 					bodyStr = string(data)
@@ -59,9 +80,17 @@ Examples:
 			if err := json.Unmarshal([]byte(bodyStr), &body); err != nil {
 				return fmt.Errorf("invalid JSON body: %w", err)
 			}
-			respData, err = c.Post(path, body)
-			if method == "PATCH" {
+			switch method {
+			case "PATCH":
 				respData, err = c.Patch(path, body)
+			case "POST", "PUT":
+				respData, err = c.Post(path, body)
+			case "DELETE":
+				respData, err = c.Delete(path)
+			case "GET":
+				return fmt.Errorf("GET requests do not accept a body")
+			default:
+				respData, err = c.Post(path, body)
 			}
 		} else {
 			switch method {
@@ -91,6 +120,26 @@ Examples:
 	},
 }
 
+// normalizeAPIPath ensures the path targets the Notion API.
+//   - Prefixes with "/" if missing.
+//   - Auto-prefixes "/v1" when the path starts with "/" but not "/v1/" (and
+//     isn't already "/v1"). A note is written to stderr so power users are
+//     aware of the rewrite.
+func normalizeAPIPath(path string) string {
+	if path == "" {
+		return path
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if path == "/v1" || strings.HasPrefix(path, "/v1/") {
+		return path
+	}
+	normalized := "/v1" + path
+	fmt.Fprintf(os.Stderr, "note: prepending /v1 to path → %s\n", normalized)
+	return normalized
+}
+
 func init() {
-	apiCmd.Flags().String("body", "", "JSON request body")
+	apiCmd.Flags().String("body", "", "JSON request body. Use @<file> to read from file, or - for stdin")
 }

--- a/cmd/api_test.go
+++ b/cmd/api_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeAPIPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/v1/users/me", "/v1/users/me"},
+		{"/v1", "/v1"},
+		{"/users/me", "/v1/users/me"},
+		{"users/me", "/v1/users/me"},
+		{"/search", "/v1/search"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeAPIPath(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeAPIPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
Polish the `notion api` escape-hatch command so first-time use stops tripping on three small paper cuts.

## Why
Tracked in #24. Summary:
1. Help example showed positional body (`notion api POST /v1/search '{...}'`), but `Usage:` line required `--body`. The positional form didn't actually work.
2. Missing `/v1/` prefix produced the opaque `invalid_request_url` with no hint.
3. No `--body @file.json` support; long PATCH bodies were awkward.

## Changes
- **Auto-prefix `/v1`** when a path starts with `/` but not `/v1/`; prints a one-line stderr `note:` so power users see the rewrite.
- **`--body @<path>`** reads body from a file (curl-style). **`--body -`** explicitly reads from stdin. Existing implicit stdin fallback for POST/PATCH/PUT kept.
- Reject GET with a body up-front (was silently dropped).
- PATCH now unconditionally routes through `c.Patch()` instead of hitting `c.Post` first then overwriting.
- Drop the misleading positional example from `--help`.

## Test plan
- `go test ./...` — green, new `TestNormalizeAPIPath` covers each path shape.
- Manual: `notion api GET /users/me` now works (with stderr note).

Closes #24