### PR TITLE
feat(block): auto-batch >100 children and split oversize rich_text

### DIFF
--- a/cmd/block.go
+++ b/cmd/block.go
@@ -191,13 +191,18 @@ var blockAppendCmd = &cobra.Command{
 	Short: "Append blocks to a page",
 	Long: `Append content to a Notion page or block.
 
-Supports plain text, block types, and markdown files.
+Supports plain text, block types, and markdown files. Large markdown files
+are handled transparently:
+  - >100 children are auto-batched into sequential PATCHes.
+  - code / rich_text exceeding Notion's 2000-char limit are split by
+    default (override with --on-oversize=truncate|fail).
 
 Examples:
   notion block append <page-id> "Hello world"
   notion block append <page-id> --type heading1 "Section Title"
   notion block append <page-id> --type code --lang go "fmt.Println()"
   notion block append <page-id> --file notes.md
+  notion block append <page-id> --file big.md --on-oversize=truncate
   notion block append <page-id> --image-url https://example.com/a.png --caption "图 1-1"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -211,6 +216,11 @@ Examples:
 		filePath, _ := cmd.Flags().GetString("file")
 		imageURL, _ := cmd.Flags().GetString("image-url")
 		caption, _ := cmd.Flags().GetString("caption")
+		onOversizeRaw, _ := cmd.Flags().GetString("on-oversize")
+		mode, err := parseOversizeMode(onOversizeRaw)
+		if err != nil {
+			return err
+		}
 
 		text := ""
 		if len(args) > 1 {
@@ -265,11 +275,12 @@ Examples:
 			return fmt.Errorf("no content to append")
 		}
 
-		reqBody := map[string]interface{}{
-			"children": children,
+		children, err = handleOversizedBlocks(children, mode)
+		if err != nil {
+			return err
 		}
 
-		data, err := c.Patch(fmt.Sprintf("/v1/blocks/%s/children", parentID), reqBody)
+		data, err := appendChildrenBatched(c, parentID, "", children)
 		if err != nil {
 			return fmt.Errorf("append block: %w", err)
 		}
@@ -370,6 +381,12 @@ Examples:
 
 		var children []map[string]interface{}
 
+		onOversizeRaw, _ := cmd.Flags().GetString("on-oversize")
+		mode, err := parseOversizeMode(onOversizeRaw)
+		if err != nil {
+			return err
+		}
+
 		if imageURL != "" {
 			children = append(children, buildExternalImageBlock(imageURL, caption))
 		} else if filePath != "" {
@@ -400,12 +417,12 @@ Examples:
 			})
 		}
 
-		reqBody := map[string]interface{}{
-			"children": children,
-			"after":    afterID,
+		children, err = handleOversizedBlocks(children, mode)
+		if err != nil {
+			return err
 		}
 
-		data, err := c.Patch(fmt.Sprintf("/v1/blocks/%s/children", parentID), reqBody)
+		data, err := appendChildrenBatched(c, parentID, afterID, children)
 		if err != nil {
 			return fmt.Errorf("insert block: %w", err)
 		}
@@ -576,12 +593,14 @@ func init() {
 	blockAppendCmd.Flags().String("file", "", "Read content from a file (each double-newline-separated section becomes a block)")
 	blockAppendCmd.Flags().String("image-url", "", "Append an external image block by URL (http/https)")
 	blockAppendCmd.Flags().String("caption", "", "Caption for --image-url (optional)")
+	blockAppendCmd.Flags().String("on-oversize", "split", "Behavior for rich_text >2000 chars: split|truncate|fail")
 	blockInsertCmd.Flags().String("after", "", "Block ID to insert after (required)")
 	blockInsertCmd.Flags().StringP("type", "t", "paragraph", "Block type")
 	blockInsertCmd.Flags().String("lang", "plain text", "Language for code blocks")
 	blockInsertCmd.Flags().String("file", "", "Read content from a file")
 	blockInsertCmd.Flags().String("image-url", "", "Insert an external image block by URL (http/https)")
 	blockInsertCmd.Flags().String("caption", "", "Caption for --image-url (optional)")
+	blockInsertCmd.Flags().String("on-oversize", "split", "Behavior for rich_text >2000 chars: split|truncate|fail")
 	blockListCmd.Flags().String("cursor", "", "Pagination cursor")
 	blockListCmd.Flags().Bool("all", false, "Fetch all pages of results")
 	blockListCmd.Flags().Int("depth", 1, "Depth of nested blocks to fetch (default 1)")

--- a/cmd/block_limits.go
+++ b/cmd/block_limits.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Notion API hard limits that the CLI absorbs transparently when possible.
+// See: https://developers.notion.com/reference/request-limits
+const (
+	// maxChildrenPerRequest is the maximum `children.length` a single
+	// PATCH /v1/blocks/<id>/children call will accept.
+	maxChildrenPerRequest = 100
+
+	// maxRichTextContentLen is the maximum length of a single rich_text
+	// item's text.content (applies to code blocks too).
+	maxRichTextContentLen = 2000
+)
+
+// oversizeMode controls behavior when a single block's text exceeds
+// maxRichTextContentLen. Values come from --on-oversize.
+type oversizeMode string
+
+const (
+	oversizeSplit    oversizeMode = "split"
+	oversizeTruncate oversizeMode = "truncate"
+	oversizeFail     oversizeMode = "fail"
+)
+
+// parseOversizeMode validates the flag value and returns the canonical enum.
+func parseOversizeMode(raw string) (oversizeMode, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", "split":
+		return oversizeSplit, nil
+	case "truncate":
+		return oversizeTruncate, nil
+	case "fail":
+		return oversizeFail, nil
+	default:
+		return "", fmt.Errorf("--on-oversize must be one of: split, truncate, fail (got %q)", raw)
+	}
+}
+
+// handleOversizedBlocks walks `blocks` and returns a new slice where every
+// block is within Notion's per-item content limit. Today only code blocks
+// (which are by far the most common offender) are split along newline
+// boundaries; other rich_text blocks are split by character.
+//
+// In `fail` mode, the first oversize block returns an error with a clear
+// message so the caller can print it verbatim.
+func handleOversizedBlocks(blocks []map[string]interface{}, mode oversizeMode) ([]map[string]interface{}, error) {
+	out := make([]map[string]interface{}, 0, len(blocks))
+	for idx, b := range blocks {
+		split, err := splitBlockIfOversize(b, idx, mode)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, split...)
+	}
+	return out, nil
+}
+
+func splitBlockIfOversize(block map[string]interface{}, idx int, mode oversizeMode) ([]map[string]interface{}, error) {
+	blockType, _ := block["type"].(string)
+	data, ok := block[blockType].(map[string]interface{})
+	if !ok {
+		return []map[string]interface{}{block}, nil
+	}
+	content, segments := extractContentFromBlock(data)
+	if segments != 1 || len(content) <= maxRichTextContentLen {
+		return []map[string]interface{}{block}, nil
+	}
+
+	switch mode {
+	case oversizeFail:
+		return nil, fmt.Errorf(
+			"block[%d] of type %q exceeds Notion's %d-char rich_text limit (%d chars); re-run with --on-oversize=split or truncate",
+			idx, blockType, maxRichTextContentLen, len(content),
+		)
+	case oversizeTruncate:
+		truncated := content[:maxRichTextContentLen]
+		newBlock := cloneBlockWithContent(block, blockType, truncated)
+		return []map[string]interface{}{newBlock}, nil
+	}
+
+	// default: split
+	parts := splitContentForNotion(content, blockType == "code")
+	result := make([]map[string]interface{}, 0, len(parts))
+	for _, part := range parts {
+		result = append(result, cloneBlockWithContent(block, blockType, part))
+	}
+	return result, nil
+}
+
+// extractContentFromBlock returns the first rich_text's text.content and
+// the number of rich_text segments in the block. When the block has more
+// than one segment (rich formatting), we conservatively skip splitting —
+// the user likely crafted that carefully and it's rarely the offender.
+func extractContentFromBlock(data map[string]interface{}) (string, int) {
+	// rich_text can be []interface{} (from API response) or
+	// []map[string]interface{} (from our parser). Handle both.
+	if rt, ok := data["rich_text"].([]map[string]interface{}); ok {
+		if len(rt) == 0 {
+			return "", 0
+		}
+		textObj, _ := rt[0]["text"].(map[string]interface{})
+		content, _ := textObj["content"].(string)
+		return content, len(rt)
+	}
+	if rt, ok := data["rich_text"].([]interface{}); ok {
+		if len(rt) == 0 {
+			return "", 0
+		}
+		first, _ := rt[0].(map[string]interface{})
+		textObj, _ := first["text"].(map[string]interface{})
+		content, _ := textObj["content"].(string)
+		return content, len(rt)
+	}
+	return "", 0
+}
+
+// splitContentForNotion slices content into ≤maxRichTextContentLen chunks.
+// For code blocks we try to cut on newline boundaries so syntax highlighting
+// still looks reasonable after the split.
+func splitContentForNotion(content string, preferNewlineBoundary bool) []string {
+	var parts []string
+	remaining := content
+	for len(remaining) > maxRichTextContentLen {
+		cut := maxRichTextContentLen
+		if preferNewlineBoundary {
+			if nl := strings.LastIndex(remaining[:maxRichTextContentLen], "\n"); nl > maxRichTextContentLen/2 {
+				// Only prefer the newline if it's not absurdly early
+				// (avoids emitting tiny first chunks for one-huge-line inputs).
+				cut = nl
+			}
+		}
+		parts = append(parts, remaining[:cut])
+		remaining = strings.TrimPrefix(remaining[cut:], "\n")
+	}
+	if remaining != "" {
+		parts = append(parts, remaining)
+	}
+	if len(parts) == 0 {
+		return []string{""}
+	}
+	return parts
+}
+
+// cloneBlockWithContent builds a new block with the same type and language
+// (if a code block) but replaces its rich_text[0].text.content with `content`.
+func cloneBlockWithContent(orig map[string]interface{}, blockType, content string) map[string]interface{} {
+	newData := map[string]interface{}{
+		"rich_text": []map[string]interface{}{
+			{"text": map[string]interface{}{"content": content}},
+		},
+	}
+	// Preserve language on code blocks.
+	if origData, ok := orig[blockType].(map[string]interface{}); ok {
+		if lang, ok := origData["language"].(string); ok {
+			newData["language"] = lang
+		}
+		// Preserve to_do checked state
+		if v, ok := origData["checked"]; ok {
+			newData["checked"] = v
+		}
+	}
+	return map[string]interface{}{
+		"object":  "block",
+		"type":    blockType,
+		blockType: newData,
+	}
+}
+
+// chunkChildren slices children into groups of at most maxChildrenPerRequest.
+func chunkChildren(children []map[string]interface{}) [][]map[string]interface{} {
+	if len(children) <= maxChildrenPerRequest {
+		return [][]map[string]interface{}{children}
+	}
+	var out [][]map[string]interface{}
+	for i := 0; i < len(children); i += maxChildrenPerRequest {
+		end := i + maxChildrenPerRequest
+		if end > len(children) {
+			end = len(children)
+		}
+		out = append(out, children[i:end])
+	}
+	return out
+}
+
+// blockAppender is the minimal client surface appendChildrenBatched needs.
+// Keeping it as an interface makes the batching logic testable without
+// hitting the network.
+type blockAppender interface {
+	Patch(path string, body interface{}) ([]byte, error)
+}
+
+// appendChildrenBatched PATCHes children in groups of ≤100, preserving
+// order. When `afterID` is non-empty it's used for the FIRST batch only
+// (Notion only accepts `after` for the initial insertion; subsequent
+// batches rely on sequential append to stay in order).
+//
+// Progress is printed to stderr when there is more than one batch, so
+// stdout can still be piped to jq etc.
+func appendChildrenBatched(c blockAppender, parentID, afterID string, children []map[string]interface{}) ([]byte, error) {
+	batches := chunkChildren(children)
+	var lastResp []byte
+	var err error
+
+	if len(batches) > 1 {
+		fmt.Fprintf(os.Stderr, "note: appending %d blocks in %d batches of ≤%d...\n",
+			len(children), len(batches), maxChildrenPerRequest)
+	}
+
+	for i, batch := range batches {
+		reqBody := map[string]interface{}{
+			"children": batch,
+		}
+		if i == 0 && afterID != "" {
+			reqBody["after"] = afterID
+		}
+		lastResp, err = c.Patch(fmt.Sprintf("/v1/blocks/%s/children", parentID), reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("batch %d/%d failed after writing %d block(s): %w",
+				i+1, len(batches), i*maxChildrenPerRequest, err)
+		}
+		if len(batches) > 1 {
+			fmt.Fprintf(os.Stderr, "  ✓ batch %d/%d (%d blocks)\n", i+1, len(batches), len(batch))
+		}
+	}
+	return lastResp, nil
+}

--- a/cmd/block_limits_test.go
+++ b/cmd/block_limits_test.go
@@ -1,0 +1,354 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestChunkChildren(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		want []int // sizes of each chunk
+	}{
+		{"empty", 0, nil},
+		{"under limit", 50, []int{50}},
+		{"exactly at limit", 100, []int{100}},
+		{"one over limit", 101, []int{100, 1}},
+		{"double limit", 200, []int{100, 100}},
+		{"triple limit + tail", 253, []int{100, 100, 53}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			children := make([]map[string]interface{}, tt.size)
+			for i := range children {
+				children[i] = map[string]interface{}{"i": i}
+			}
+			got := chunkChildren(children)
+			if tt.size == 0 {
+				if len(got) != 1 || len(got[0]) != 0 {
+					t.Errorf("empty input: got %d chunks", len(got))
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d chunks, want %d", len(got), len(tt.want))
+			}
+			for i, n := range tt.want {
+				if len(got[i]) != n {
+					t.Errorf("chunk %d size = %d, want %d", i, len(got[i]), n)
+				}
+			}
+			// Verify order preserved across chunks.
+			seen := 0
+			for _, batch := range got {
+				for _, b := range batch {
+					if b["i"] != seen {
+						t.Fatalf("order broken: batch item i=%v, want %d", b["i"], seen)
+					}
+					seen++
+				}
+			}
+		})
+	}
+}
+
+func TestHandleOversizedBlocks_CodeSplit(t *testing.T) {
+	big := strings.Repeat("a", 3000)
+	block := map[string]interface{}{
+		"object": "block",
+		"type":   "code",
+		"code": map[string]interface{}{
+			"rich_text": []map[string]interface{}{
+				{"text": map[string]interface{}{"content": big}},
+			},
+			"language": "typescript",
+		},
+	}
+
+	result, err := handleOversizedBlocks([]map[string]interface{}{block}, oversizeSplit)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("got %d blocks, want 2 (3000 / 2000 = 2 chunks)", len(result))
+	}
+	// Each chunk must preserve the code type and language, and be ≤2000 chars.
+	for i, b := range result {
+		if b["type"] != "code" {
+			t.Errorf("chunk %d type = %v, want code", i, b["type"])
+		}
+		code := b["code"].(map[string]interface{})
+		if code["language"] != "typescript" {
+			t.Errorf("chunk %d language = %v, want typescript", i, code["language"])
+		}
+		rt := code["rich_text"].([]map[string]interface{})
+		content := rt[0]["text"].(map[string]interface{})["content"].(string)
+		if len(content) > maxRichTextContentLen {
+			t.Errorf("chunk %d content len = %d, > limit %d", i, len(content), maxRichTextContentLen)
+		}
+	}
+}
+
+func TestHandleOversizedBlocks_NewlineBoundaryPreferred(t *testing.T) {
+	// Build a 3000-char block with a newline around position 1800 (within
+	// the "not absurdly early" window, so it should be used as the cut).
+	first := strings.Repeat("a", 1800)
+	second := strings.Repeat("b", 1200)
+	content := first + "\n" + second
+	block := map[string]interface{}{
+		"object": "block",
+		"type":   "code",
+		"code": map[string]interface{}{
+			"rich_text": []map[string]interface{}{
+				{"text": map[string]interface{}{"content": content}},
+			},
+			"language": "plain text",
+		},
+	}
+	result, err := handleOversizedBlocks([]map[string]interface{}{block}, oversizeSplit)
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(result))
+	}
+	first0 := result[0]["code"].(map[string]interface{})["rich_text"].([]map[string]interface{})[0]["text"].(map[string]interface{})["content"].(string)
+	if first0 != first {
+		t.Errorf("first chunk should be cut at newline: len=%d (want %d)", len(first0), len(first))
+	}
+}
+
+func TestHandleOversizedBlocks_Truncate(t *testing.T) {
+	big := strings.Repeat("x", 2500)
+	block := map[string]interface{}{
+		"object": "block",
+		"type":   "paragraph",
+		"paragraph": map[string]interface{}{
+			"rich_text": []map[string]interface{}{
+				{"text": map[string]interface{}{"content": big}},
+			},
+		},
+	}
+	result, err := handleOversizedBlocks([]map[string]interface{}{block}, oversizeTruncate)
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("truncate should keep 1 block, got %d", len(result))
+	}
+	rt := result[0]["paragraph"].(map[string]interface{})["rich_text"].([]map[string]interface{})
+	content := rt[0]["text"].(map[string]interface{})["content"].(string)
+	if len(content) != maxRichTextContentLen {
+		t.Errorf("truncated len = %d, want %d", len(content), maxRichTextContentLen)
+	}
+}
+
+func TestHandleOversizedBlocks_Fail(t *testing.T) {
+	big := strings.Repeat("y", 2500)
+	block := map[string]interface{}{
+		"object": "block",
+		"type":   "code",
+		"code": map[string]interface{}{
+			"rich_text": []map[string]interface{}{
+				{"text": map[string]interface{}{"content": big}},
+			},
+			"language": "go",
+		},
+	}
+	_, err := handleOversizedBlocks([]map[string]interface{}{block}, oversizeFail)
+	if err == nil {
+		t.Fatal("expected error in fail mode")
+	}
+	if !strings.Contains(err.Error(), "2000-char") {
+		t.Errorf("error should mention the limit: %v", err)
+	}
+}
+
+func TestHandleOversizedBlocks_PassThroughSmall(t *testing.T) {
+	block := map[string]interface{}{
+		"object":    "block",
+		"type":      "paragraph",
+		"paragraph": map[string]interface{}{"rich_text": []map[string]interface{}{{"text": map[string]interface{}{"content": "short"}}}},
+	}
+	result, err := handleOversizedBlocks([]map[string]interface{}{block}, oversizeSplit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 1 {
+		t.Errorf("expected pass-through, got %d blocks", len(result))
+	}
+}
+
+func TestParseOversizeMode(t *testing.T) {
+	cases := map[string]oversizeMode{
+		"":         oversizeSplit,
+		"split":    oversizeSplit,
+		"SPLIT":    oversizeSplit,
+		"truncate": oversizeTruncate,
+		"fail":     oversizeFail,
+	}
+	for in, want := range cases {
+		got, err := parseOversizeMode(in)
+		if err != nil {
+			t.Errorf("%q: unexpected error: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("%q: got %q, want %q", in, got, want)
+		}
+	}
+	if _, err := parseOversizeMode("bogus"); err == nil {
+		t.Error("bogus input should error")
+	}
+}
+
+// ---- appendChildrenBatched integration test ----
+
+type recordingAppender struct {
+	calls []map[string]interface{}
+	fail  int // 1-indexed batch to fail, 0 = never
+}
+
+func (r *recordingAppender) Patch(path string, body interface{}) ([]byte, error) {
+	m, _ := body.(map[string]interface{})
+	// deep-clone so the caller mutating the slice after our recording
+	// doesn't affect what we captured.
+	data, _ := json.Marshal(m)
+	var copy map[string]interface{}
+	json.Unmarshal(data, &copy)
+	copy["__path"] = path
+	r.calls = append(r.calls, copy)
+	if r.fail != 0 && len(r.calls) == r.fail {
+		return nil, &mockAPIError{"simulated failure"}
+	}
+	return []byte(`{"results":[]}`), nil
+}
+
+type mockAPIError struct{ msg string }
+
+func (e *mockAPIError) Error() string { return e.msg }
+
+func TestAppendChildrenBatched_SplitsAt100(t *testing.T) {
+	children := make([]map[string]interface{}, 253)
+	for i := range children {
+		children[i] = map[string]interface{}{"i": i}
+	}
+	rec := &recordingAppender{}
+	if _, err := appendChildrenBatched(rec, "parent", "", children); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 3 {
+		t.Fatalf("got %d PATCH calls, want 3", len(rec.calls))
+	}
+	got := []int{
+		len(rec.calls[0]["children"].([]interface{})),
+		len(rec.calls[1]["children"].([]interface{})),
+		len(rec.calls[2]["children"].([]interface{})),
+	}
+	if got[0] != 100 || got[1] != 100 || got[2] != 53 {
+		t.Errorf("chunk sizes = %v, want [100 100 53]", got)
+	}
+	// `after` should only be set on the first batch when provided.
+	for _, c := range rec.calls {
+		if _, ok := c["after"]; ok {
+			t.Errorf("no batch should have 'after' when caller passed empty afterID: %v", c)
+		}
+	}
+}
+
+func TestAppendChildrenBatched_AfterIDOnlyFirstBatch(t *testing.T) {
+	children := make([]map[string]interface{}, 120)
+	for i := range children {
+		children[i] = map[string]interface{}{"i": i}
+	}
+	rec := &recordingAppender{}
+	if _, err := appendChildrenBatched(rec, "parent", "anchor-xyz", children); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.calls) != 2 {
+		t.Fatalf("got %d calls, want 2", len(rec.calls))
+	}
+	if rec.calls[0]["after"] != "anchor-xyz" {
+		t.Errorf("first batch should carry after=anchor-xyz, got %v", rec.calls[0]["after"])
+	}
+	if _, ok := rec.calls[1]["after"]; ok {
+		t.Errorf("second batch must not carry 'after'")
+	}
+}
+
+func TestAppendChildrenBatched_PartialFailureMessage(t *testing.T) {
+	children := make([]map[string]interface{}, 250)
+	for i := range children {
+		children[i] = map[string]interface{}{"i": i}
+	}
+	rec := &recordingAppender{fail: 2}
+	_, err := appendChildrenBatched(rec, "parent", "", children)
+	if err == nil {
+		t.Fatal("expected error from failing batch")
+	}
+	// Message should tell the user which batch failed and how many had been
+	// written already.
+	if !strings.Contains(err.Error(), "batch 2/3") {
+		t.Errorf("expected 'batch 2/3' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "100 block") {
+		t.Errorf("expected '100 block' in error, got: %v", err)
+	}
+}
+
+func TestAppendChildrenBatched_UnderLimitSingleCall(t *testing.T) {
+	children := make([]map[string]interface{}, 10)
+	for i := range children {
+		children[i] = map[string]interface{}{"i": i}
+	}
+	rec := &recordingAppender{}
+	if _, err := appendChildrenBatched(rec, "parent", "", children); err != nil {
+		t.Fatal(err)
+	}
+	if len(rec.calls) != 1 {
+		t.Errorf("got %d calls, want 1", len(rec.calls))
+	}
+}
+
+// End-to-end: parse a markdown document that blows both limits at once
+// and verify the final block list is within both constraints.
+func TestBigDocPipeline_AllLimitsRespected(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 150; i++ {
+		sb.WriteString("- item ")
+		sb.WriteString(strings.Repeat("x", 10))
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n```go\n")
+	sb.WriteString(strings.Repeat("y", 3000))
+	sb.WriteString("\n```\n")
+	blocks := parseMarkdownToBlocks(sb.String())
+	// 150 bullets + 1 oversize code block (will split into 2) = 152 after
+	// oversize handling, still >100 so batching must kick in.
+	processed, err := handleOversizedBlocks(blocks, oversizeSplit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(processed) < 151 {
+		t.Errorf("processed len = %d, want >=151", len(processed))
+	}
+	chunks := chunkChildren(processed)
+	if len(chunks) < 2 {
+		t.Errorf("expected >=2 chunks, got %d", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if len(chunk) > maxChildrenPerRequest {
+			t.Errorf("chunk %d size %d > %d", i, len(chunk), maxChildrenPerRequest)
+		}
+		for _, b := range chunk {
+			if b["type"] == "code" {
+				rt := b["code"].(map[string]interface{})["rich_text"].([]map[string]interface{})
+				content := rt[0]["text"].(map[string]interface{})["content"].(string)
+				if len(content) > maxRichTextContentLen {
+					t.Errorf("code content len %d > limit", len(content))
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What
Absorb Notion's two hard request limits inside the CLI so long markdown documents stop requiring manual pre-splitting.

## Why
Tracked in #21. Notion rejects PATCH `/v1/blocks/<id>/children` when either:
- `children.length > 100`, or
- any `rich_text[N].text.content.length > 2000` (code blocks included).

Both limits are fixed and known at parse time. Before this PR, a ~14KB postmortem with 124 blocks + one 2134-char code block needed to be manually cut into 5 separate invocations. This is mechanical work the CLI can do.

## Changes
New file `cmd/block_limits.go`:
- `chunkChildren` — slice into groups of ≤100.
- `appendChildrenBatched(c, parent, after, children)`:
  - sequential PATCHes, order preserved;
  - `after` anchor attached to **the first batch only** (Notion won't let subsequent inserts reference a block from the same transaction);
  - progress printed to **stderr** (`note: appending 123 blocks in 2 batches...`) so `--format json` still pipes cleanly through jq;
  - on partial failure: `batch 2/3 failed after writing 100 block(s): <api error>`.
- `handleOversizedBlocks` + `parseOversizeMode`:
  - default `split`: cut on newline boundaries for code blocks, char boundary otherwise;
  - `truncate`: keep only the first 2000 chars;
  - `fail`: explicit error, opt-in.
  - Preserves `code.language` and `to_do.checked` across splits.

New flag: `--on-oversize=split|truncate|fail` on both `block append` and `block insert`.

## Test plan
- Unit tests for chunk sizing, order preservation, oversize modes, newline-boundary preference, after-anchor placement, partial-failure error text.
- End-to-end test: 150-bullet + 3000-char-code-block document passes through `parseMarkdownToBlocks → handleOversizedBlocks → chunkChildren`, and every resulting chunk respects both Notion limits.

Closes #21