### PR TITLE
feat(file): accept stdin and http(s) URLs as upload sources

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -32,6 +32,16 @@ type fileUploadOutcome struct {
 	BlockType   string
 }
 
+// fileSource is everything uploadFile needs about the bytes it's about to
+// send. It abstracts over local files, stdin, and http(s) URLs so the
+// core upload flow stays single-path.
+type fileSource struct {
+	Name        string
+	Size        int64
+	ContentType string
+	Data        []byte
+}
+
 var fileCmd = &cobra.Command{
 	Use:   "file",
 	Short: "Work with file uploads",
@@ -98,13 +108,23 @@ Examples:
 }
 
 var fileUploadCmd = &cobra.Command{
-	Use:   "upload <file-path>",
+	Use:   "upload <file-path|url|->",
 	Short: "Upload a file to Notion",
 	Long: `Upload a file using Notion's file upload API (multi-step).
 
+The source can be:
+  <path>          a local file on disk
+  <http(s) url>   a remote resource (streamed, not saved to disk)
+  -               stdin (commonly used with a pipeline like curl | upload)
+
+For non-path sources --name is recommended because we can't always
+derive a sensible filename.
+
 Examples:
   notion file upload ./document.pdf
-  notion file upload ./image.png --to <page-id>`,
+  notion file upload ./image.png --to <page-id>
+  notion file upload https://example.com/chart.png --name chart.png
+  curl -sSL https://example.com/chart.png | notion file upload - --name chart.png`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token, err := getToken()
@@ -112,13 +132,14 @@ Examples:
 			return err
 		}
 
-		filePath := args[0]
+		source := args[0]
 		targetID, _ := cmd.Flags().GetString("to")
+		nameOverride, _ := cmd.Flags().GetString("name")
 
 		c := client.New(token)
 		c.SetDebug(debugMode)
 
-		outcome, err := uploadFile(c, filePath, targetID)
+		outcome, err := uploadFromAny(c, source, nameOverride, targetID)
 		if err != nil {
 			return err
 		}
@@ -139,21 +160,168 @@ Examples:
 	},
 }
 
-func uploadFile(api fileUploadAPI, filePath, targetID string) (*fileUploadOutcome, error) {
-	fileInfo, err := os.Stat(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("file not found: %w", err)
+// uploadFromAny dispatches the source string to one of the three loaders
+// (file / stdin / http) and then funnels into the existing upload path.
+func uploadFromAny(api fileUploadAPI, source, nameOverride, targetID string) (*fileUploadOutcome, error) {
+	var src *fileSource
+	var err error
+
+	switch {
+	case source == "-":
+		src, err = loadSourceFromStdin(nameOverride)
+	case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
+		src, err = loadSourceFromURL(source, nameOverride)
+	default:
+		src, err = loadSourceFromPath(source, nameOverride)
 	}
-
-	fileName := filepath.Base(filePath)
-	fileSize := fileInfo.Size()
-
-	contentType, err := detectFileContentType(filePath)
 	if err != nil {
 		return nil, err
 	}
+	return uploadFromSource(api, src, targetID)
+}
 
-	createData, err := api.Post("/v1/file_uploads", buildCreateFileUploadBody(fileName, contentType, fileSize))
+func loadSourceFromPath(filePath, nameOverride string) (*fileSource, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("file not found: %w", err)
+	}
+	name := filepath.Base(filePath)
+	if nameOverride != "" {
+		name = nameOverride
+	}
+	ct, err := detectFileContentType(filePath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	return &fileSource{Name: name, Size: fi.Size(), ContentType: ct, Data: data}, nil
+}
+
+func loadSourceFromStdin(nameOverride string) (*fileSource, error) {
+	if nameOverride == "" {
+		return nil, fmt.Errorf("--name is required when reading from stdin (notion file upload - --name <filename>)")
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, fmt.Errorf("read stdin: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("stdin contained no data")
+	}
+	return &fileSource{
+		Name:        nameOverride,
+		Size:        int64(len(data)),
+		ContentType: sniffContentType(nameOverride, data),
+		Data:        data,
+	}, nil
+}
+
+// loadSourceFromURL fetches a remote resource and returns it as a
+// fileSource. Redirects follow curl-style defaults. No external auth
+// mechanism is added here — callers who need auth can still do:
+//
+//	curl -H 'Authorization: Bearer X' ... | notion file upload - --name foo
+//
+// which covers the advanced case without bloating this command.
+func loadSourceFromURL(url, nameOverride string) (*fileSource, error) {
+	resp, err := http.Get(url) //nolint:gosec // URL comes from the user's own CLI arg
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download %s: HTTP %d %s", url, resp.StatusCode, resp.Status)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+
+	name := nameOverride
+	if name == "" {
+		name = filenameFromURL(url, resp.Header.Get("Content-Disposition"))
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = sniffContentType(name, data)
+	}
+
+	return &fileSource{
+		Name:        name,
+		Size:        int64(len(data)),
+		ContentType: ct,
+		Data:        data,
+	}, nil
+}
+
+// filenameFromURL derives a best-effort filename. Prefers the
+// Content-Disposition attachment hint, then the last path segment.
+func filenameFromURL(rawURL, contentDisposition string) string {
+	if contentDisposition != "" {
+		if _, params, err := mime.ParseMediaType(contentDisposition); err == nil {
+			if name := params["filename"]; name != "" {
+				return filepath.Base(name)
+			}
+		}
+	}
+	// Strip query string and hash.
+	base := rawURL
+	if i := strings.IndexAny(base, "?#"); i >= 0 {
+		base = base[:i]
+	}
+	// Cut scheme and authority so filepath.Base doesn't return the host.
+	if i := strings.Index(base, "://"); i >= 0 {
+		rest := base[i+3:]
+		if j := strings.Index(rest, "/"); j >= 0 {
+			base = rest[j:]
+		} else {
+			base = ""
+		}
+	}
+	base = strings.TrimRight(base, "/")
+	base = filepath.Base(base)
+	if base == "" || base == "/" || base == "." {
+		return "download"
+	}
+	return base
+}
+
+// sniffContentType combines extension-based and byte-signature detection,
+// falling back to application/octet-stream.
+func sniffContentType(name string, data []byte) string {
+	if ext := filepath.Ext(name); ext != "" {
+		if ct := mime.TypeByExtension(ext); ct != "" {
+			return ct
+		}
+	}
+	if len(data) == 0 {
+		return "application/octet-stream"
+	}
+	if len(data) > 512 {
+		return http.DetectContentType(data[:512])
+	}
+	return http.DetectContentType(data)
+}
+
+// uploadFile is the legacy entry point kept for tests and the --to flow.
+// New code should call uploadFromAny / uploadFromSource.
+func uploadFile(api fileUploadAPI, filePath, targetID string) (*fileUploadOutcome, error) {
+	src, err := loadSourceFromPath(filePath, "")
+	if err != nil {
+		return nil, err
+	}
+	return uploadFromSource(api, src, targetID)
+}
+
+// uploadFromSource runs the two-step create + send dance against Notion,
+// then optionally attaches the new upload to a target page.
+func uploadFromSource(api fileUploadAPI, src *fileSource, targetID string) (*fileUploadOutcome, error) {
+	createData, err := api.Post("/v1/file_uploads", buildCreateFileUploadBody(src.Name, src.ContentType, src.Size))
 	if err != nil {
 		return nil, fmt.Errorf("create file upload: %w", err)
 	}
@@ -168,12 +336,7 @@ func uploadFile(api fileUploadAPI, filePath, targetID string) (*fileUploadOutcom
 		return nil, fmt.Errorf("no upload ID returned")
 	}
 
-	fileBytes, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("read file: %w", err)
-	}
-
-	sendData, err := api.UploadFileContent(uploadID, fileName, contentType, fileBytes)
+	sendData, err := api.UploadFileContent(uploadID, src.Name, src.ContentType, src.Data)
 	if err != nil {
 		return nil, fmt.Errorf("send file content: %w", err)
 	}
@@ -190,9 +353,9 @@ func uploadFile(api fileUploadAPI, filePath, targetID string) (*fileUploadOutcom
 	outcome := &fileUploadOutcome{
 		Result:      result,
 		UploadID:    uploadID,
-		FileName:    fileName,
-		FileSize:    fileSize,
-		ContentType: contentType,
+		FileName:    src.Name,
+		FileSize:    src.Size,
+		ContentType: src.ContentType,
 	}
 
 	if strings.TrimSpace(targetID) == "" {
@@ -200,8 +363,8 @@ func uploadFile(api fileUploadAPI, filePath, targetID string) (*fileUploadOutcom
 	}
 
 	resolvedTargetID := util.ResolveID(targetID)
-	blockType := mediaBlockTypeForContentType(contentType)
-	if _, err := api.Patch(fmt.Sprintf("/v1/blocks/%s/children", resolvedTargetID), buildFileUploadAppendRequest(uploadID, contentType)); err != nil {
+	blockType := mediaBlockTypeForContentType(src.ContentType)
+	if _, err := api.Patch(fmt.Sprintf("/v1/blocks/%s/children", resolvedTargetID), buildFileUploadAppendRequest(uploadID, src.ContentType)); err != nil {
 		return nil, fmt.Errorf("attach file to page: %w", err)
 	}
 
@@ -285,6 +448,7 @@ func mediaBlockTypeForContentType(contentType string) string {
 
 func init() {
 	fileUploadCmd.Flags().String("to", "", "Target page ID to attach file to")
+	fileUploadCmd.Flags().String("name", "", "Override filename (required for stdin source, optional for URL)")
 	fileCmd.AddCommand(fileListCmd)
 	fileCmd.AddCommand(fileUploadCmd)
 }

--- a/cmd/file_source_test.go
+++ b/cmd/file_source_test.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFilenameFromURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		disp string
+		want string
+	}{
+		{"https://x.com/a/b/chart.png", "", "chart.png"},
+		{"https://x.com/a/b/chart.png?foo=bar", "", "chart.png"},
+		{"https://x.com/a/b/chart.png#frag", "", "chart.png"},
+		{"https://x.com/download?id=123", `attachment; filename="report.pdf"`, "report.pdf"},
+		{"https://x.com/", "", "download"},
+	}
+	for _, tc := range cases {
+		got := filenameFromURL(tc.url, tc.disp)
+		if got != tc.want {
+			t.Errorf("filenameFromURL(%q, %q) = %q, want %q", tc.url, tc.disp, got, tc.want)
+		}
+	}
+}
+
+func TestSniffContentType_ByExtension(t *testing.T) {
+	got := sniffContentType("chart.png", []byte{})
+	if !strings.HasPrefix(got, "image/png") {
+		t.Errorf("png by ext: %q", got)
+	}
+}
+
+func TestSniffContentType_ByBytes(t *testing.T) {
+	// PNG magic header.
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	got := sniffContentType("mystery", png)
+	if !strings.HasPrefix(got, "image/png") {
+		t.Errorf("png by bytes: %q", got)
+	}
+}
+
+func TestLoadSourceFromStdin_RequiresName(t *testing.T) {
+	_, err := loadSourceFromStdin("")
+	if err == nil || !strings.Contains(err.Error(), "--name") {
+		t.Errorf("expected --name required error, got %v", err)
+	}
+}
+
+func TestLoadSourceFromStdin_ReadsBytes(t *testing.T) {
+	// Redirect os.Stdin to a pipe with known content.
+	r, w, _ := os.Pipe()
+	w.Write([]byte("hello"))
+	w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	src, err := loadSourceFromStdin("note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Name != "note.txt" {
+		t.Errorf("name = %q", src.Name)
+	}
+	if string(src.Data) != "hello" {
+		t.Errorf("data = %q", src.Data)
+	}
+	if src.Size != 5 {
+		t.Errorf("size = %d", src.Size)
+	}
+	if !strings.HasPrefix(src.ContentType, "text/plain") {
+		t.Errorf("content-type = %q", src.ContentType)
+	}
+}
+
+func TestLoadSourceFromStdin_EmptyRejected(t *testing.T) {
+	r, w, _ := os.Pipe()
+	w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	_, err := loadSourceFromStdin("x.txt")
+	if err == nil || !strings.Contains(err.Error(), "no data") {
+		t.Errorf("expected no-data error, got %v", err)
+	}
+}
+
+func TestLoadSourceFromURL_BasicFlow(t *testing.T) {
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(png)
+	}))
+	defer srv.Close()
+
+	src, err := loadSourceFromURL(srv.URL+"/a/b/chart.png?token=abc", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Name != "chart.png" {
+		t.Errorf("name = %q, want chart.png", src.Name)
+	}
+	if src.ContentType != "image/png" {
+		t.Errorf("content-type = %q", src.ContentType)
+	}
+	if string(src.Data) != string(png) {
+		t.Errorf("data mismatch")
+	}
+}
+
+func TestLoadSourceFromURL_NameOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("body"))
+	}))
+	defer srv.Close()
+
+	src, err := loadSourceFromURL(srv.URL+"/opaque", "override.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Name != "override.txt" {
+		t.Errorf("name = %q", src.Name)
+	}
+}
+
+func TestLoadSourceFromURL_ContentDispositionFilename(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition", `attachment; filename="report.pdf"`)
+		w.Write([]byte("%PDF-1.4\n"))
+	}))
+	defer srv.Close()
+
+	src, err := loadSourceFromURL(srv.URL+"/download?id=123", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src.Name != "report.pdf" {
+		t.Errorf("name = %q, want report.pdf", src.Name)
+	}
+}
+
+func TestLoadSourceFromURL_HTTPErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := loadSourceFromURL(srv.URL+"/missing.png", "")
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 in error, got %v", err)
+	}
+}
+
+// Integration: uploadFromAny with a URL source should hit the upload
+// pipeline exactly the same way as a local-file source.
+func TestUploadFromAny_URLUsesSamePipeline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("pngbytes"))
+	}))
+	defer srv.Close()
+
+	mock := &mockFileUploadClient{}
+	outcome, err := uploadFromAny(mock, srv.URL+"/chart.png", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mock.postPath != "/v1/file_uploads" {
+		t.Errorf("expected create POST, got %q", mock.postPath)
+	}
+	body := mock.postBody.(map[string]interface{})
+	if body["filename"] != "chart.png" {
+		t.Errorf("filename = %v", body["filename"])
+	}
+	if body["content_type"] != "image/png" {
+		t.Errorf("content_type = %v", body["content_type"])
+	}
+	if outcome.FileName != "chart.png" {
+		t.Errorf("outcome name = %q", outcome.FileName)
+	}
+	if string(mock.sendFileContents) != "pngbytes" {
+		t.Errorf("body mismatch")
+	}
+}
+
+// Integration: stdin source.
+func TestUploadFromAny_StdinUsesSamePipeline(t *testing.T) {
+	r, w, _ := os.Pipe()
+	w.Write([]byte("hello from stdin"))
+	w.Close()
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+
+	mock := &mockFileUploadClient{}
+	outcome, err := uploadFromAny(mock, "-", "note.txt", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.FileName != "note.txt" {
+		t.Errorf("name = %q", outcome.FileName)
+	}
+	if outcome.FileSize != 16 {
+		t.Errorf("size = %d", outcome.FileSize)
+	}
+	if string(mock.sendFileContents) != "hello from stdin" {
+		t.Errorf("body = %q", mock.sendFileContents)
+	}
+}


### PR DESCRIPTION
## What
Let `notion file upload` accept three kinds of source:

| argument | behavior |
|---|---|
| `<path>` | local file (unchanged) |
| `-` | read from stdin |
| `http(s)://…` | HTTP GET, follows redirects |

Plus a new `--name <filename>` flag to override the filename (required for stdin, optional for URLs whose path segment is opaque).

## Why
Tracked in #26. Before this PR, uploading anything behind a URL required a manual two-step with `curl -o /tmp/... && notion file upload /tmp/... && rm`. And stdin wasn't supported at all, so pipelines like `gh run view --log | notion file upload - --name run.log` were impossible.

## Changes
`cmd/file.go` refactored around a `fileSource` abstraction. Three loaders funnel into a single `uploadFromSource(api, src, targetID)` function that performs the existing two-step create + send + (optional) attach flow.

- `loadSourceFromPath` — unchanged semantics, preserved for legacy callers (`uploadFile` back-compat shim still works).
- `loadSourceFromStdin` — requires `--name`; rejects empty stdin up-front.
- `loadSourceFromURL` — reads `Content-Type`, derives filename from `Content-Disposition` or URL path, strips query/hash, handles non-2xx with a clear error. Scheme + path cuts mean `https://x.com/` sensibly falls back to `download` instead of `x.com`.

Deliberately **out of scope** for this PR (the curl-pipe still works for these):
- custom auth headers for the URL loader,
- chunked / streaming uploads (Notion's `single_part` mode, unchanged).

## Test plan
- `httptest` servers for URL success, `Content-Disposition` filename extraction, and 404 propagation.
- `os.Pipe` stdin redirection for stdin tests.
- Integration tests prove URL and stdin sources hit the exact same mocked `POST /v1/file_uploads` → `UploadFileContent` sequence as a local file.

Closes #26