### PR TITLE
Support app.notion.com copied page URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 | 일시 | 유형 | 범위 | 변경내용 (목적 포함) |
 |---|---|---|---|
+| 2026-06-05 14:19 | fix | util | `app.notion.com/p/...` 복사 URL에서 page ID 추출 지원 — `<page-id\|url>` 입력 호환성 개선 (#57) |
 | 2026-04-30 14:20 | feat | page | `page markdown` (GET /v1/pages/:id/markdown) + `page set-markdown` (PATCH, 4가지 모드 replace/append/after/range) 추가 — Notion 서버사이드 마크다운 I/O 일등공민화 (#37) |
 | 2026-04-30 14:20 | feat | page | `page property` 추가: GET /v1/pages/:id/properties/:id 자동 페이지네이션 — 25개 초과 relation/rollup/rich_text 사일런트 절단 수정 (#38) |
 | 2026-04-30 14:20 | feat | block | `block update --file <md>` / `--markdown` 지원 — append/insert와 일관된 마크다운 경험, 블록 타입 불일치 fail-fast (#36) |

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -8,7 +8,8 @@ import (
 var (
 	// Match Notion URLs like https://www.notion.so/page-title-abc123def456
 	// or https://www.notion.so/workspace/abc123def456?v=...
-	notionURLRe = regexp.MustCompile(`(?:notion\.so|notion\.site)/(?:.*?)([a-f0-9]{32}|[a-f0-9-]{36})`)
+	// or https://app.notion.com/p/page-title-abc123def456?source=copy_link
+	notionURLRe = regexp.MustCompile(`(?:notion\.so|notion\.site|app\.notion\.com)/(?:.*?)([a-f0-9]{32}|[a-f0-9-]{36})`)
 	uuidRe      = regexp.MustCompile(`^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}$`)
 	plainIDRe   = regexp.MustCompile(`^[a-f0-9]{32}$`)
 )
@@ -19,7 +20,7 @@ func ResolveID(input string) string {
 	input = strings.TrimSpace(input)
 
 	// Full URL
-	if strings.Contains(input, "notion.so") || strings.Contains(input, "notion.site") {
+	if strings.Contains(input, "notion.so") || strings.Contains(input, "notion.site") || strings.Contains(input, "app.notion.com") {
 		matches := notionURLRe.FindStringSubmatch(input)
 		if len(matches) > 1 {
 			return formatUUID(matches[1])

--- a/internal/util/url_test.go
+++ b/internal/util/url_test.go
@@ -34,6 +34,16 @@ func TestResolveID(t *testing.T) {
 			want:  "c9e9f681-ec8e-4eb7-be25-bbbe479b05b0",
 		},
 		{
+			name:  "app.notion.com /p copied URL with slug",
+			input: "https://app.notion.com/p/My-Page-c9e9f681ec8e4eb7be25bbbe479b05b0?source=copy_link",
+			want:  "c9e9f681-ec8e-4eb7-be25-bbbe479b05b0",
+		},
+		{
+			name:  "app.notion.com /p copied URL without slug",
+			input: "https://app.notion.com/p/c9e9f681ec8e4eb7be25bbbe479b05b0",
+			want:  "c9e9f681-ec8e-4eb7-be25-bbbe479b05b0",
+		},
+		{
 			name:  "short string passthrough",
 			input: "abc123",
 			want:  "abc123",


### PR DESCRIPTION
## Summary

- support Notion copied page URLs under `app.notion.com/p/...`
- extract the 32-character page id from copied `/p/` links before calling the API
- add resolver tests for copied URLs with and without a slug
- update the changelog

Fixes #57.

## Validation

- `go test ./internal/util`
- `go test ./...`
- `git diff --cached --check`
- `security-gate precommit --staged`
